### PR TITLE
Bootstrap 4 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,42 @@ The JSON response will now look like:
 }
 ```
 
+## Using Bootstrap 4
+
+By default, Paginator prints Bootstrap 3-compatible HTML in Leaf, however it is possible to configure it to use Bootstrap 4. You can add a `paginator.json` file to your Config directory with the values:
+
+```json
+{
+    "useBootstrap4": true
+}
+```
+
+You can alternatively manually build the Paginator Provider and add it to your `Droplet`:
+
+```swift
+let paginator = PaginatorProvider(useBootstrap4: true)
+drop.addProvider(paginator)
+```
+
+## Specifying an Aria Label 
+
+The Paginator HTML adds in Aria labels for accessibility options, such as screen readers. It is recommended that you add a label to your paginator to assist this. This can be done in the same way as the Bootstrap 4 options. Either in `paginator.json`:
+
+```json
+{
+    "paginatorLabel": "Blog Post Pages"
+}
+```
+
+Or manually:
+
+```swift
+let paginator = PaginatorProvider(paginationLabel: "Blog Post Pages")
+drop.addProvider(paginator)
+```
+
+The two configurable options (label and Bootstrap 4) can obviously be combined.
+
 ## 🏆 Credits
 This package is developed and maintained by the Vapor team at [Nodes](https://www.nodes.dk).
 

--- a/Sources/Paginator+Leaf.swift
+++ b/Sources/Paginator+Leaf.swift
@@ -101,8 +101,7 @@ extension PaginatorTag {
         if useBootstrap4 {
             navClass = "paginator"
             ulClass = "pagination justify-content-center"
-        }
-        else {
+        } else {
             navClass = "paginator text-center"
             ulClass = "pagination"
         }
@@ -135,8 +134,7 @@ extension PaginatorTag {
         if useBootstrap4 {
             linkClass = "page-link"
             liClass = "page-item"
-        }
-        else {
+        } else {
             linkClass = nil
             liClass = nil
         }
@@ -174,17 +172,14 @@ extension PaginatorTag {
             
             if title == "«" {
                 linkString += " rel=\"prev\" aria-label=\"Previous\"><span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span>"
-            }
-            else if title == "»" {
+            } else if title == "»" {
                 linkString += " rel=\"next\" aria-label=\"Next\"><span aria-hidden=\"true\">»</span><span class=\"sr-only\">Next</span>"
-            }
-            else {
+            } else {
                 linkString += ">\(title)"
             }
             
             linkString += "</a>"
-        }
-        else {
+        } else {
             linkString += "<span"
             
             if let linkClass = linkClass {
@@ -193,11 +188,9 @@ extension PaginatorTag {
             
             if title == "«" {
                 linkString += " aria-label=\"Previous\" aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span>"
-            }
-            else if title == "»" {
+            } else if title == "»" {
                 linkString += " aria-label=\"Next\" aria-hidden=\"true\">»</span><span class=\"sr-only\">Next</span>"
-            }
-            else {
+            } else {
                 linkString += ">\(title)</span>"
                 
                 if active {

--- a/Sources/Paginator+Leaf.swift
+++ b/Sources/Paginator+Leaf.swift
@@ -60,30 +60,68 @@ public final class PaginatorTag: Tag {
 }
 
 extension PaginatorTag {
+    
     func buildBackButton(url: String?) -> Bytes {
+        
+        let liClass: String
+        let linkClass: String
+        if useBootstrap4 {
+            liClass = "page-item"
+            linkClass = "page-link"
+        }
+        else {
+            liClass = ""
+            linkClass = ""
+        }
+        
         guard let url = url else {
-            return "<li class=\"disabled\"><span>«</span></li>\n".bytes
+            return "<li class=\"disabled \(liClass)\"><span class=\"\(linkClass)\" aria-label=\"Previous\" aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span></li>\n".bytes
         }
 
-        return "<li><a href=\"\(url)\" rel=\"prev\">«</a></li>\n".bytes
+        return "<li class=\"\(liClass)\"><a href=\"\(url)\" rel=\"prev\" aria-label=\"Previous\" class=\"\(linkClass)\"><span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span></a></li>\n".bytes
     }
     
     func buildForwardButton(url: String?) -> Bytes {
-        guard let url = url else {
-            return "<li class=\"disabled\"><span>»</span></li>\n".bytes
+
+        let liClass: String
+        let linkClass: String
+        if useBootstrap4 {
+            liClass = "page-item"
+            linkClass = "page-link"
+        }
+        else {
+            liClass = ""
+            linkClass = ""
         }
         
-        return "<li><a href=\"\(url)\" rel=\"next\">»</a></li>\n".bytes
+        guard let url = url else {
+            return "<li class=\"disabled \(liClass)\"><span aria-hidden=\"true\" class=\"\(linkClass)\">»</span></span><span class=\"sr-only\">Next</span></li>\n".bytes
+        }
+        
+        return "<li class=\"\(liClass)\"><a href=\"\(url)\" rel=\"next\" class=\"\(linkClass)\" aria-label=\"Next\"><span class=\"sr-only\">Next</span><span aria-hidden=\"true\">»</span></a></li>\n".bytes
     }
     
     func buildLinks(currentPage: Int, count: Int) -> Bytes {
         var bytes: Bytes = []
         
+        let linkClass: String
+        let liClass: String
+        let activeSpan = "<span class=\"sr-only\">(current)</span>"
+        
+        if useBootstrap4 {
+            linkClass = "page-link"
+            liClass = "page-item"
+        }
+        else {
+            linkClass = ""
+            liClass = ""
+        }
+        
         for i in 1...count {
             if i == currentPage {
-                bytes += "<li class=\"active\"><span>\(i)</span></li>\n".bytes
+                bytes += "<li class=\"active \(liClass)\"><span class=\"\(linkClass)\">\(i)</span>\(activeSpan)</li>\n".bytes
             } else {
-                bytes += "<li><a href=\"?page=\(i)\">\(i)</a></li>\n".bytes
+                bytes += "<li><a href=\"?page=\(i)\" class=\"\(linkClass)\">\(i)</a></li>\n".bytes
             }
         }
         
@@ -93,7 +131,17 @@ extension PaginatorTag {
     func buildNavigation(currentPage: Int, totalPages: Int, links: [String : Polymorphic]) -> Node {
         var bytes: Bytes = []
         
-        let header = "<nav class=\"paginator text-center\">\n<ul class=\"pagination\">\n".bytes
+        let navClass: String
+        let ulClass: String
+        if useBootstrap4 {
+            navClass = "paginator"
+            ulClass = "pagination justify-content-center"
+        }
+        else {
+            navClass = "paginator text-center"
+            ulClass = "pagination"
+        }
+        let header = "<nav class=\"\(navClass)\">\n<ul class=\"\(ulClass)\">\n".bytes
         let footer = "</ul>\n</nav>".bytes
         
         bytes += header

--- a/Sources/Paginator+Leaf.swift
+++ b/Sources/Paginator+Leaf.swift
@@ -9,9 +9,11 @@ public final class PaginatorTag: Tag {
     }
     
     fileprivate let useBootstrap4: Bool
+    fileprivate let paginationLabel: String?
     
-    public init(useBootstrap4: Bool = false) {
+    public init(useBootstrap4: Bool = false, paginationLabel: String? = nil) {
         self.useBootstrap4 = useBootstrap4
+        self.paginationLabel = paginationLabel
     }
     
     public let name = "paginator"
@@ -141,7 +143,7 @@ extension PaginatorTag {
             navClass = "paginator text-center"
             ulClass = "pagination"
         }
-        let header = "<nav class=\"\(navClass)\">\n<ul class=\"\(ulClass)\">\n".bytes
+        let header = "<nav class=\"\(navClass)\" aria-label=\"\(paginationLabel ?? "")\">\n<ul class=\"\(ulClass)\">\n".bytes
         let footer = "</ul>\n</nav>".bytes
         
         bytes += header

--- a/Sources/Paginator+Leaf.swift
+++ b/Sources/Paginator+Leaf.swift
@@ -8,7 +8,11 @@ public final class PaginatorTag: Tag {
         case expectedValidPaginator
     }
     
-    public init() {}
+    fileprivate let useBootstrap4: Bool
+    
+    public init(useBootstrap4: Bool = false) {
+        self.useBootstrap4 = useBootstrap4
+    }
     
     public let name = "paginator"
     

--- a/Sources/Paginator+Leaf.swift
+++ b/Sources/Paginator+Leaf.swift
@@ -72,20 +72,8 @@ extension PaginatorTag {
     }
     
     func buildForwardButton(url: String?) -> Bytes {
-
-        let liClass: String
-        let linkClass: String
-        if useBootstrap4 {
-            liClass = "page-item"
-            linkClass = "page-link"
-        }
-        else {
-            liClass = ""
-            linkClass = ""
-        }
-        
         guard let url = url else {
-            return "<li class=\"disabled \(liClass)\"><span aria-hidden=\"true\" class=\"\(linkClass)\">»</span></span><span class=\"sr-only\">Next</span></li>\n".bytes
+            return buildLink(title: "»", active: false, link: nil, disabled: true).bytes
         }
         
         return buildLink(title: "»", active: false, link: url, disabled: false).bytes

--- a/Sources/Provider.swift
+++ b/Sources/Provider.swift
@@ -9,17 +9,20 @@ public final class PaginatorProvider: Provider {
             return
         }
         
-        renderer.stem.register(PaginatorTag(useBootstrap4: useBootstrap4))
+        renderer.stem.register(PaginatorTag(useBootstrap4: useBootstrap4, paginationLabel: paginationLabel))
     }
     
     fileprivate let useBootstrap4: Bool
+    fileprivate let paginationLabel: String?
     
-    public init(useBootstrap4: Bool = false) {
+    public init(useBootstrap4: Bool = false, paginationLabel: String? = nil) {
         self.useBootstrap4 = useBootstrap4
+        self.paginationLabel = paginationLabel
     }
     public init(config: Config) throws {
         // TODO
         useBootstrap4 = false
+        paginationLabel = nil
     }
     public func afterInit(_ drop: Droplet) {}
     public func beforeRun(_: Droplet) {}

--- a/Sources/Provider.swift
+++ b/Sources/Provider.swift
@@ -19,10 +19,34 @@ public final class PaginatorProvider: Provider {
         self.useBootstrap4 = useBootstrap4
         self.paginationLabel = paginationLabel
     }
+    
+    /**
+        Creates a Paginator provider from a `paginator.json` config file. Both the config file
+        and the options are optional, and it will default to Bootstrap 3 with no Aria Label if
+        none supplied
+     
+         The file may contain similar JSON:
+         
+         {
+            "useBootstrap4": true,
+            "paginatorLabel": "Blog Post Pages"
+         }
+     */
     public init(config: Config) throws {
-        // TODO
-        useBootstrap4 = false
-        paginationLabel = nil
+        
+        var useBootstrap4Value = false
+        var paginatorLabelValue: String? = nil
+        
+        
+        if let paginatorConfig = config["paginator"]?.object {
+            paginatorLabelValue = paginatorConfig["paginatorLabel"]?.string
+            if let bootstrap4 = paginatorConfig["useBootstrap4"]?.bool {
+                useBootstrap4Value = bootstrap4
+            }
+        }
+        
+        useBootstrap4 = useBootstrap4Value
+        paginationLabel = paginatorLabelValue
     }
     public func afterInit(_ drop: Droplet) {}
     public func beforeRun(_: Droplet) {}

--- a/Sources/Provider.swift
+++ b/Sources/Provider.swift
@@ -9,10 +9,18 @@ public final class PaginatorProvider: Provider {
             return
         }
         
-        renderer.stem.register(PaginatorTag())
+        renderer.stem.register(PaginatorTag(useBootstrap4: useBootstrap4))
     }
     
-    public init(config: Config) throws {}
+    fileprivate let useBootstrap4: Bool
+    
+    public init(useBootstrap4: Bool = false) {
+        self.useBootstrap4 = useBootstrap4
+    }
+    public init(config: Config) throws {
+        // TODO
+        useBootstrap4 = false
+    }
     public func afterInit(_ drop: Droplet) {}
     public func beforeRun(_: Droplet) {}
 }

--- a/Tests/PaginatorTests/EntityTests.swift
+++ b/Tests/PaginatorTests/EntityTests.swift
@@ -53,7 +53,17 @@ class EntityTest: XCTestCase {
         
         XCTAssertNil(paginator.previousPage)
         XCTAssertNotNil(paginator.nextPage)
-        XCTAssertEqual(paginator.nextPage, "/users?count=2&page=2&search=Brett")
+        
+        let components = URLComponents(string: paginator.nextPage!)
+        let queries = components?.queryItems
+        
+        let expectedQueries = [URLQueryItem(name: "count", value: "2"), URLQueryItem(name: "page", value: "2"), URLQueryItem(name: "search", value: "Brett")]
+        
+        for query in expectedQueries {
+            XCTAssertTrue((queries?.contains(query))!)
+        }
+        
+        XCTAssertEqual(components?.path, "/users")
     }
     
     func testMakeNode() {

--- a/Tests/PaginatorTests/EntityTests.swift
+++ b/Tests/PaginatorTests/EntityTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 import HTTP
 import Fluent
+import Foundation
 
 @testable import Paginator
 

--- a/Tests/PaginatorTests/EntityTests.swift
+++ b/Tests/PaginatorTests/EntityTests.swift
@@ -32,8 +32,15 @@ class EntityTest: XCTestCase {
         XCTAssertEqual(paginator.dataKey, "data")
         
         XCTAssertNotNil(paginator.previousPage)
+        let previousPageComponents = URLComponents(string: paginator.previousPage!)
+        let expectedPreviousPageComponents = URLComponents(string: "/users?page=1&count=2")
+        XCTAssertEqual(previousPageComponents, expectedPreviousPageComponents)
         XCTAssertEqual(paginator.previousPage, "/users?page=1&count=2")
+        
         XCTAssertNotNil(paginator.nextPage)
+        let nextPageComponents = URLComponents(string: paginator.nextPage!)
+        let expectedNextPageComponents = URLComponents(string: "/users?page=3&count=2")
+        XCTAssertEqual(nextPageComponents, expectedNextPageComponents)
         XCTAssertEqual(paginator.nextPage, "/users?page=3&count=2")
         
         XCTAssertEqual(paginator.totalPages, 3)
@@ -97,7 +104,10 @@ class EntityTest: XCTestCase {
         }
         
         XCTAssertNil(links["previous"]?.string)
-        XCTAssertEqual(links["next"]?.string, "/users?page=2&count=4")
+        
+        let actualNextPathComponents = URLComponents(string: (links["next"]?.string)!)
+        let expectedPathComponents = URLComponents(string: "/users?page=2&count=4")
+        XCTAssertEqual(expectedPathComponents, actualNextPathComponents)
     }
     
     func testEntityQueryExtension() {

--- a/Tests/PaginatorTests/EntityTests.swift
+++ b/Tests/PaginatorTests/EntityTests.swift
@@ -63,15 +63,9 @@ class EntityTest: XCTestCase {
         XCTAssertNotNil(paginator.nextPage)
         
         let components = URLComponents(string: paginator.nextPage!)
-        let queries = components?.queryItems
+        let expectedComponets = URLComponents(string: "/users?count=2&page=2&search=Brett")
         
-        let expectedQueries = [URLQueryItem(name: "count", value: "2"), URLQueryItem(name: "page", value: "2"), URLQueryItem(name: "search", value: "Brett")]
-        
-        for query in expectedQueries {
-            XCTAssertTrue((queries?.contains(query))!)
-        }
-        
-        XCTAssertEqual(components?.path, "/users")
+        XCTAssertEqual(components, expectedComponets)
     }
     
     func testMakeNode() {

--- a/Tests/PaginatorTests/EntityTests.swift
+++ b/Tests/PaginatorTests/EntityTests.swift
@@ -34,15 +34,21 @@ class EntityTest: XCTestCase {
         
         XCTAssertNotNil(paginator.previousPage)
         let previousPageComponents = URLComponents(string: paginator.previousPage!)
-        let expectedPreviousPageComponents = URLComponents(string: "/users?page=1&count=2")
-        XCTAssertEqual(previousPageComponents, expectedPreviousPageComponents)
-        XCTAssertEqual(paginator.previousPage, "/users?page=1&count=2")
+        let previousPagePath = previousPageComponents?.path
+        let previousPageQuery = previousPageComponents?.query
+        let expectedPreviousPageQueryNode = Node(formURLEncoded: "page=1&count=2".bytes)
+        let actualPreviousPageQueryNode = Node(formURLEncoded: previousPageQuery!.bytes)
+        XCTAssertEqual(expectedPreviousPageQueryNode, actualPreviousPageQueryNode)
+        XCTAssertEqual(previousPagePath, "/users")
         
         XCTAssertNotNil(paginator.nextPage)
         let nextPageComponents = URLComponents(string: paginator.nextPage!)
-        let expectedNextPageComponents = URLComponents(string: "/users?page=3&count=2")
-        XCTAssertEqual(nextPageComponents, expectedNextPageComponents)
-        XCTAssertEqual(paginator.nextPage, "/users?page=3&count=2")
+        let nextPagePath = nextPageComponents?.path
+        let nextPageQuery = nextPageComponents?.query
+        let expectedNextPageQueryNode = Node(formURLEncoded: "page=3&count=2".bytes)
+        let actualNextPageQueryNode = Node(formURLEncoded: nextPageQuery!.bytes)
+        XCTAssertEqual(expectedNextPageQueryNode, actualNextPageQueryNode)
+        XCTAssertEqual(nextPagePath, "/users")
         
         XCTAssertEqual(paginator.totalPages, 3)
         
@@ -62,10 +68,15 @@ class EntityTest: XCTestCase {
         XCTAssertNil(paginator.previousPage)
         XCTAssertNotNil(paginator.nextPage)
         
-        let components = URLComponents(string: paginator.nextPage!)
-        let expectedComponets = URLComponents(string: "/users?count=2&page=2&search=Brett")
+        let components = URLComponents(string: "/users?count=2&search=Brett&page=2")
+        let query = components?.query
+        let path = components?.path
         
-        XCTAssertEqual(components, expectedComponets)
+        let queryNode = Node(formURLEncoded: query!.bytes)
+        let expectedQueryNode = Node(formURLEncoded: "count=2&search=Brett&page=2".bytes)
+        
+        XCTAssertEqual(queryNode, expectedQueryNode)
+        XCTAssertEqual(path, "/users")
     }
     
     func testMakeNode() {
@@ -101,8 +112,10 @@ class EntityTest: XCTestCase {
         XCTAssertNil(links["previous"]?.string)
         
         let actualNextPathComponents = URLComponents(string: (links["next"]?.string)!)
-        let expectedPathComponents = URLComponents(string: "/users?page=2&count=4")
-        XCTAssertEqual(expectedPathComponents, actualNextPathComponents)
+        let expectedQueryNode = Node(formURLEncoded: "page=2&count=4".bytes)
+        let actualQueryNode = Node(formURLEncoded: actualNextPathComponents!.query!.bytes)
+        XCTAssertEqual(expectedQueryNode, actualQueryNode)
+        XCTAssertEqual(actualNextPathComponents?.path, "/users")
     }
     
     func testEntityQueryExtension() {

--- a/Tests/PaginatorTests/LeafTests.swift
+++ b/Tests/PaginatorTests/LeafTests.swift
@@ -31,7 +31,7 @@ class LeafTests: XCTestCase {
             return
         }
         
-        let expectedHTML = "<nav class=\"paginator text-center\">\n<ul class=\"pagination\">\n<li><a href=\"/posts?page=1\" rel=\"prev\">«</a></li>\n<li><a href=\"?page=1\">1</a></li>\n<li class=\"active\"><span>2</span></li>\n<li><a href=\"?page=3\">3</a></li>\n<li><a href=\"?page=4\">4</a></li>\n<li><a href=\"?page=5\">5</a></li>\n<li><a href=\"?page=6\">6</a></li>\n<li><a href=\"?page=7\">7</a></li>\n<li><a href=\"?page=8\">8</a></li>\n<li><a href=\"?page=9\">9</a></li>\n<li><a href=\"?page=10\">10</a></li>\n<li><a href=\"/posts?page=3\" rel=\"next\">»</a></li>\n</ul>\n</nav>"
+        let expectedHTML = "<nav class=\"paginator text-center\">\n<ul class=\"pagination\">\n<li><a href=\"/posts?page=1\" rel=\"prev\" aria-label=\"Previous\"><span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span></a></li>\n<li><a href=\"?page=1\">1</a></li>\n<li class=\"active\"><span>2</span><span class=\"sr-only\">(current)</span></li>\n<li><a href=\"?page=3\">3</a></li>\n<li><a href=\"?page=4\">4</a></li>\n<li><a href=\"?page=5\">5</a></li>\n<li><a href=\"?page=6\">6</a></li>\n<li><a href=\"?page=7\">7</a></li>\n<li><a href=\"?page=8\">8</a></li>\n<li><a href=\"?page=9\">9</a></li>\n<li><a href=\"?page=10\">10</a></li>\n<li><a href=\"/posts?page=3\" rel=\"next\" aria-label=\"Next\"><span aria-hidden=\"true\">»</span><span class=\"sr-only\">Next</span></a></li>\n</ul>\n</nav>"
         
         XCTAssertEqual(bytes.string, expectedHTML)
     }

--- a/Tests/PaginatorTests/LeafTests.swift
+++ b/Tests/PaginatorTests/LeafTests.swift
@@ -36,6 +36,106 @@ class LeafTests: XCTestCase {
         XCTAssertEqual(bytes.string, expectedHTML)
     }
     
+    func testRunTagWithAriaLabel() {
+        let tag = PaginatorTag(paginationLabel: "Some Aria Label Pages")
+        let paginator = buildPaginator()
+        
+        let result = expectNoThrow() {
+            return try run(
+                tag: tag,
+                context: paginator,
+                arguments: [
+                    .variable(path: [], value: paginator)
+                ]
+            )
+            
+            }!
+        
+        guard result != nil, case .bytes(let bytes) = result! else {
+            XCTFail("Should have returned bytes")
+            return
+        }
+        
+        let expectedHTML = "<nav class=\"paginator text-center\" aria-label=\"Some Aria Label Pages\">\n<ul class=\"pagination\">\n<li><a href=\"/posts?page=1\" rel=\"prev\" aria-label=\"Previous\"><span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span></a></li>\n<li><a href=\"?page=1\">1</a></li>\n<li class=\"active\"><span>2</span><span class=\"sr-only\">(current)</span></li>\n<li><a href=\"?page=3\">3</a></li>\n<li><a href=\"?page=4\">4</a></li>\n<li><a href=\"?page=5\">5</a></li>\n<li><a href=\"?page=6\">6</a></li>\n<li><a href=\"?page=7\">7</a></li>\n<li><a href=\"?page=8\">8</a></li>\n<li><a href=\"?page=9\">9</a></li>\n<li><a href=\"?page=10\">10</a></li>\n<li><a href=\"/posts?page=3\" rel=\"next\" aria-label=\"Next\"><span aria-hidden=\"true\">»</span><span class=\"sr-only\">Next</span></a></li>\n</ul>\n</nav>"
+        
+        XCTAssertEqual(bytes.string, expectedHTML)
+    }
+    
+    func testRunTagWithExplicitBootstrap3() {
+        let tag = PaginatorTag(useBootstrap4: false)
+        let paginator = buildPaginator()
+        
+        let result = expectNoThrow() {
+            return try run(
+                tag: tag,
+                context: paginator,
+                arguments: [
+                    .variable(path: [], value: paginator)
+                ]
+            )
+            
+            }!
+        
+        guard result != nil, case .bytes(let bytes) = result! else {
+            XCTFail("Should have returned bytes")
+            return
+        }
+        
+        let expectedHTML = "<nav class=\"paginator text-center\">\n<ul class=\"pagination\">\n<li><a href=\"/posts?page=1\" rel=\"prev\" aria-label=\"Previous\"><span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span></a></li>\n<li><a href=\"?page=1\">1</a></li>\n<li class=\"active\"><span>2</span><span class=\"sr-only\">(current)</span></li>\n<li><a href=\"?page=3\">3</a></li>\n<li><a href=\"?page=4\">4</a></li>\n<li><a href=\"?page=5\">5</a></li>\n<li><a href=\"?page=6\">6</a></li>\n<li><a href=\"?page=7\">7</a></li>\n<li><a href=\"?page=8\">8</a></li>\n<li><a href=\"?page=9\">9</a></li>\n<li><a href=\"?page=10\">10</a></li>\n<li><a href=\"/posts?page=3\" rel=\"next\" aria-label=\"Next\"><span aria-hidden=\"true\">»</span><span class=\"sr-only\">Next</span></a></li>\n</ul>\n</nav>"
+        
+        XCTAssertEqual(bytes.string, expectedHTML)
+    }
+    
+    func testRunTagWithBootstrap4() {
+        let tag = PaginatorTag(useBootstrap4: true)
+        let paginator = buildPaginator()
+        
+        let result = expectNoThrow() {
+            return try run(
+                tag: tag,
+                context: paginator,
+                arguments: [
+                    .variable(path: [], value: paginator)
+                ]
+            )
+            
+            }!
+        
+        guard result != nil, case .bytes(let bytes) = result! else {
+            XCTFail("Should have returned bytes")
+            return
+        }
+        
+        let expectedHTML = "<nav class=\"paginator\">\n<ul class=\"pagination justify-content-center\">\n<li class=\"page-item\"><a href=\"/posts?page=1\" class=\"page-link\" rel=\"prev\" aria-label=\"Previous\"><span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span></a></li>\n<li class=\"page-item\"><a href=\"?page=1\" class=\"page-link\">1</a></li>\n<li class=\"active page-item\"><span class=\"page-link\">2</span><span class=\"sr-only\">(current)</span></li>\n<li class=\"page-item\"><a href=\"?page=3\" class=\"page-link\">3</a></li>\n<li class=\"page-item\"><a href=\"?page=4\" class=\"page-link\">4</a></li>\n<li class=\"page-item\"><a href=\"?page=5\" class=\"page-link\">5</a></li>\n<li class=\"page-item\"><a href=\"?page=6\" class=\"page-link\">6</a></li>\n<li class=\"page-item\"><a href=\"?page=7\" class=\"page-link\">7</a></li>\n<li class=\"page-item\"><a href=\"?page=8\" class=\"page-link\">8</a></li>\n<li class=\"page-item\"><a href=\"?page=9\" class=\"page-link\">9</a></li>\n<li class=\"page-item\"><a href=\"?page=10\" class=\"page-link\">10</a></li>\n<li class=\"page-item\"><a href=\"/posts?page=3\" class=\"page-link\" rel=\"next\" aria-label=\"Next\"><span aria-hidden=\"true\">»</span><span class=\"sr-only\">Next</span></a></li>\n</ul>\n</nav>"
+        
+        XCTAssertEqual(bytes.string, expectedHTML)
+    }
+    
+    func testRunTagWithBootstrap4AndAriaLabel() {
+        let tag = PaginatorTag(useBootstrap4: true, paginationLabel: "Some Pages")
+        let paginator = buildPaginator()
+        
+        let result = expectNoThrow() {
+            return try run(
+                tag: tag,
+                context: paginator,
+                arguments: [
+                    .variable(path: [], value: paginator)
+                ]
+            )
+            
+            }!
+        
+        guard result != nil, case .bytes(let bytes) = result! else {
+            XCTFail("Should have returned bytes")
+            return
+        }
+        
+        let expectedHTML = "<nav class=\"paginator\" aria-label=\"Some Pages\">\n<ul class=\"pagination justify-content-center\">\n<li class=\"page-item\"><a href=\"/posts?page=1\" class=\"page-link\" rel=\"prev\" aria-label=\"Previous\"><span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span></a></li>\n<li class=\"page-item\"><a href=\"?page=1\" class=\"page-link\">1</a></li>\n<li class=\"active page-item\"><span class=\"page-link\">2</span><span class=\"sr-only\">(current)</span></li>\n<li class=\"page-item\"><a href=\"?page=3\" class=\"page-link\">3</a></li>\n<li class=\"page-item\"><a href=\"?page=4\" class=\"page-link\">4</a></li>\n<li class=\"page-item\"><a href=\"?page=5\" class=\"page-link\">5</a></li>\n<li class=\"page-item\"><a href=\"?page=6\" class=\"page-link\">6</a></li>\n<li class=\"page-item\"><a href=\"?page=7\" class=\"page-link\">7</a></li>\n<li class=\"page-item\"><a href=\"?page=8\" class=\"page-link\">8</a></li>\n<li class=\"page-item\"><a href=\"?page=9\" class=\"page-link\">9</a></li>\n<li class=\"page-item\"><a href=\"?page=10\" class=\"page-link\">10</a></li>\n<li class=\"page-item\"><a href=\"/posts?page=3\" class=\"page-link\" rel=\"next\" aria-label=\"Next\"><span aria-hidden=\"true\">»</span><span class=\"sr-only\">Next</span></a></li>\n</ul>\n</nav>"
+        
+        XCTAssertEqual(bytes.string, expectedHTML)
+    }
+    
     func testRunTagFailedTwoArgs() {
         let tag = PaginatorTag()
         

--- a/Tests/PaginatorTests/PaginatorTests.swift
+++ b/Tests/PaginatorTests/PaginatorTests.swift
@@ -7,14 +7,9 @@ import Vapor
 
 class PaginatorTests: XCTestCase {
     static var allTests = [
-        ("testExample", testExample),
         ("testRequestQueryExtension", testRequestQueryExtension)
     ]
-    
-    func testExample() {
-        XCTAssertEqual(2+2, 4)
-    }
-    
+
     func testRequestQueryExtension() {
         var request = try! Request(method: .get, uri: "/?key=value")
         request = try! request.addingValues(["hello": "world"])


### PR DESCRIPTION
This PR adds the ability for the Paginator to be configured to output Bootstrap 4 compatible HTML. It also adds in accessibility support for the HTML in both Bootstrap 3 and Bootstrap 4 and allows an Aria Label to be specified for the Paginator `<nav>` tag for Screen Readers and other assistive technologies.

No breaking changes, by default it uses Bootstrap 3 with no label, it just now adds some accessibility labels.