### PR TITLE
Pass down context and transformations

### DIFF
--- a/Sources/Paginator+Entity.swift
+++ b/Sources/Paginator+Entity.swift
@@ -21,7 +21,8 @@ extension Entity {
         page currentPage: Int = 1,
         pageName: String = "page",
         dataKey: String = "data",
-        request: Request
+        request: Request,
+        transform: (([Self]) throws -> Node)? = nil
     ) throws -> Paginator<Self> {
         return try Paginator(
             query: Self.query(),
@@ -29,6 +30,7 @@ extension Entity {
             perPage: perPage,
             pageName: pageName,
             dataKey: dataKey,
+            transform: transform,
             request: request
         )
     }
@@ -54,7 +56,8 @@ extension Query {
         page currentPage: Int = 1,
         pageName: String = "page",
         dataKey: String = "data",
-        request: Request
+        request: Request,
+        transform: (([T]) throws -> Node)? = nil
     ) throws -> Paginator<T> {
         return try Paginator(
             query: self,
@@ -62,6 +65,7 @@ extension Query {
             perPage: perPage,
             pageName: pageName,
             dataKey: dataKey,
+            transform: transform,
             request: request
         )
     }
@@ -84,9 +88,9 @@ extension Paginator {
         
         baseURI = request.uri
         uriQueries = request.query
-        
         total = entities.count
-        data = try entities.makeNode()
+        data = entities
+        transform = nil
     }
 }
 

--- a/Sources/Paginator+Entity.swift
+++ b/Sources/Paginator+Entity.swift
@@ -71,29 +71,6 @@ extension Query {
     }
 }
 
-extension Paginator {
-    public init(
-        _ entities: [EntityType],
-        page currentPage: Int = 1,
-        perPage: Int,
-        pageName: String = "page",
-        dataKey: String = "data",
-        request: Request
-    ) throws {
-        query = try EntityType.query()
-        self.currentPage = currentPage
-        self.perPage = perPage
-        self.pageName = pageName
-        self.dataKey = dataKey
-        
-        baseURI = request.uri
-        uriQueries = request.query
-        total = entities.count
-        data = entities
-        transform = nil
-    }
-}
-
 extension Sequence where Iterator.Element: Entity {
     public func paginator(
         _ perPage: Int,

--- a/Sources/Paginator.swift
+++ b/Sources/Paginator.swift
@@ -4,7 +4,7 @@ import Core
 import Vapor
 import Fluent
 
-public struct Paginator<EntityType: Entity> {
+public class Paginator<EntityType: Entity> {
     public var currentPage: Int
     public var perPage: Int
     
@@ -70,10 +70,31 @@ public struct Paginator<EntityType: Entity> {
 
         self.data = try extractEntityData()
     }
+    
+    public init(
+        _ entities: [EntityType],
+        page currentPage: Int = 1,
+        perPage: Int,
+        pageName: String = "page",
+        dataKey: String = "data",
+        request: Request
+    ) throws {
+        query = try EntityType.query()
+        self.currentPage = currentPage
+        self.perPage = perPage
+        self.pageName = pageName
+        self.dataKey = dataKey
+        
+        baseURI = request.uri
+        uriQueries = request.query
+        total = entities.count
+        data = entities
+        transform = nil
+    }
 }
 
 extension Paginator {
-    mutating func extractEntityData() throws -> [EntityType] {
+    func extractEntityData() throws -> [EntityType] {
         if let page = uriQueries?[pageName]?.int {
             currentPage = page
         }


### PR DESCRIPTION
This PR adds the ability to pass down a context through Paginator's `makeNode(context:)` down to the `EntityType`'s `makeNode(context:)`. For users who don't support `context` there's a more involved `Transformation` closure.

```swift
let paginator = try User.paginator(10, request: request) { users in
    return try users.map {
        $0.name = "💉"
    }.makeNode()
}
```

Fixes #14 and fixes #1.