### PR TITLE
Feature/vapor 2 keep query params in leaf

### DIFF
--- a/Sources/Paginator+Leaf.swift
+++ b/Sources/Paginator+Leaf.swift
@@ -46,7 +46,14 @@ public final class PaginatorTag: Tag {
             throw Error.expectedValidPaginator(message: "Expected the keys \(Keys.currentPage.key), \(Keys.totalPages.key) and links, got: \(keys)")
         }
         
-        return buildNavigation(currentPage: currentPage, totalPages: totalPages, links: links)
+        let queries = paginator["queries"]
+
+        return buildNavigation(
+            currentPage: currentPage,
+            totalPages: totalPages,
+            links: links,
+            queries: queries
+        )
     }
     
     public func shouldRender(
@@ -78,7 +85,11 @@ extension PaginatorTag {
         return buildLink(title: "»", active: false, link: url, disabled: false).bytes
     }
     
-    func buildLinks(currentPage: Int, count: Int) -> Bytes {
+    func buildLinks(
+        currentPage: Int,
+        count: Int,
+        queries: Node?
+    ) -> Bytes {
         var bytes: Bytes = []
         
         if count == 0 {
@@ -86,17 +97,38 @@ extension PaginatorTag {
         }
         
         for i in 1...count {
+            let path = PaginatorHelper.buildPath(
+                page: i,
+                count: count,
+                uriQueries: queries
+            )
+
             if i == currentPage {
-                bytes += buildLink(title: "\(i)", active: true, link: nil, disabled: false).bytes
+                bytes += buildLink(
+                    title: "\(i)",
+                    active: true,
+                    link: nil,
+                    disabled: false
+                ).bytes
             } else {
-                bytes += buildLink(title: "\(i)", active: false, link: "?page=\(i)", disabled: false).bytes
+                bytes += buildLink(
+                    title: "\(i)",
+                    active: false,
+                    link: path,
+                    disabled: false
+                ).bytes
             }
         }
         
         return bytes
     }
     
-    func buildNavigation(currentPage: Int, totalPages: Int, links: [String : Node]) -> Node {
+    func buildNavigation(
+        currentPage: Int,
+        totalPages: Int,
+        links: [String : Node],
+        queries: Node?
+    ) -> Node {
         var bytes: Bytes = []
         
         let navClass: String
@@ -120,7 +152,7 @@ extension PaginatorTag {
         
         bytes += buildBackButton(url: links["previous"]?.string)
         
-        bytes += buildLinks(currentPage: currentPage, count: totalPages)
+        bytes += buildLinks(currentPage: currentPage, count: totalPages, queries: queries)
         
         bytes += buildForwardButton(url: links["next"]?.string)
         

--- a/Sources/Paginator.swift
+++ b/Sources/Paginator.swift
@@ -229,17 +229,3 @@ extension Node {
         }.joined(separator: "&")
     }
 }
-
-extension Request {
-    public func addingValues(_ newQueries: [String : String]) throws -> Request {
-        if query == nil {
-            query = Node.object([:])
-        }
-
-        newQueries.forEach {
-            query![$0.key] = .string($0.value)
-        }
-
-        return self
-    }
-}

--- a/Sources/Paginator.swift
+++ b/Sources/Paginator.swift
@@ -35,7 +35,13 @@ public class Paginator<EntityType: Entity> where EntityType: NodeConvertible {
         let previous = currentPage - 1
         guard previous >= 1 else { return nil }
 
-        return buildPath(page: previous, count: perPage)
+        return PaginatorHelper.buildPath(
+            baseURI: baseURI.path,
+            page: previous,
+            count: perPage,
+            uriQueries: uriQueries,
+            pageName: pageName
+        )
     }
 
     public var nextPage: String? {
@@ -43,7 +49,13 @@ public class Paginator<EntityType: Entity> where EntityType: NodeConvertible {
         let next = currentPage + 1
         guard next <= totalPages else { return nil }
 
-        return buildPath(page: next, count: perPage)
+        return PaginatorHelper.buildPath(
+            baseURI: baseURI.path,
+            page: next,
+            count: perPage,
+            uriQueries: uriQueries,
+            pageName: pageName
+        )
     }
 
     public var data: [EntityType]?
@@ -154,26 +166,11 @@ extension Paginator {
     }
 }
 
-extension Paginator {
-    func buildPath(page: Int, count: Int) -> String? {
-        var urlQueriesRaw = uriQueries ?? [:]
-        urlQueriesRaw[pageName] = .number(.int(page))
-        urlQueriesRaw["count"] = .number(.int(count))
-
-        guard let urlQueries = urlQueriesRaw.formEncode() else { return nil }
-
-        return [
-            baseURI.path,
-            "?",
-            urlQueries
-        ].joined()
-    }
-}
-
 enum Keys {
     case perPage
     case currentPage
     case totalPages
+    case queries
 
     internal var key: String {
         let convention = Database.default?.keyNamingConvention ?? .camelCase
@@ -187,6 +184,8 @@ enum Keys {
 
         case .totalPages:
             return convention == .camelCase ? "totalPages" : "total_pages"
+        case .queries:
+            return "queries"
         }
     }
 
@@ -201,6 +200,7 @@ extension Paginator: NodeRepresentable {
         try paginator.set(Keys.perPage.key, perPage)
         try paginator.set(Keys.currentPage.key, currentPage)
         try paginator.set(Keys.totalPages.key, totalPages)
+        try paginator.set(Keys.queries.key, uriQueries)
 
         var links = Node.object([:])
         try links.set("previous", previousPage)

--- a/Sources/PaginatorHelper.swift
+++ b/Sources/PaginatorHelper.swift
@@ -1,0 +1,25 @@
+import Vapor
+
+struct PaginatorHelper {
+    static func buildPath(
+        baseURI: String = "",
+        page: Int,
+        count: Int,
+        uriQueries: Node?,
+        pageName: String = "page"
+    ) -> String? {
+        var urlQueriesRaw = uriQueries ?? [:]
+        urlQueriesRaw[pageName] = .number(.int(page))
+        if urlQueriesRaw["count"]?.string != nil {
+            urlQueriesRaw["count"] = .number(.int(count))
+        }
+
+        guard let urlQueries = urlQueriesRaw.formEncode() else { return nil }
+
+        return [
+            baseURI,
+            "?",
+            urlQueries
+        ].joined()
+    }
+}

--- a/Tests/PaginatorTests/EntityTests.swift
+++ b/Tests/PaginatorTests/EntityTests.swift
@@ -9,7 +9,6 @@ import Foundation
 class EntityTest: XCTestCase {
     static var allTests = [
         ("testBasic", testBasic),
-        ("testAddingQueries", testAddingQueries),
         ("testMakeNode", testMakeNode),
         ("testEntityQueryExtension", testEntityQueryExtension),
     ]
@@ -58,29 +57,6 @@ class EntityTest: XCTestCase {
         XCTAssertEqual(paginator.totalPages, 3)
         XCTAssertNotNil(paginator.total)
         XCTAssertEqual(paginator.total, 6)
-    }
-    
-    func testAddingQueries() {
-        let request = Request(method: .get, uri: "/users")
-        
-        //TODO(Brett): add `expect` tools
-        let paginator = try! TestUserEntity.paginator(
-            2,
-            request: request.addingValues(["search": "Brett"])
-        )
-        
-        XCTAssertNil(paginator.previousPage)
-        XCTAssertNotNil(paginator.nextPage)
-        
-        let components = URLComponents(string: "/users?count=2&search=Brett&page=2")
-        let query = components?.query
-        let path = components?.path
-        
-        let queryNode = Node(formURLEncoded: query!.bytes, allowEmptyValues: true)
-        let expectedQueryNode = Node(formURLEncoded: "count=2&search=Brett&page=2".bytes, allowEmptyValues: true)
-        
-        assertUnorderedEquals(queryNode, expectedQueryNode)
-        XCTAssertEqual(path, "/users")
     }
     
     func testMakeNode() {

--- a/Tests/PaginatorTests/EntityTests.swift
+++ b/Tests/PaginatorTests/EntityTests.swift
@@ -9,6 +9,7 @@ import Foundation
 class EntityTest: XCTestCase {
     static var allTests = [
         ("testBasic", testBasic),
+        ("testBasicWithCount", testBasicWithCount),
         ("testMakeNode", testMakeNode),
         ("testEntityQueryExtension", testEntityQueryExtension),
     ]
@@ -38,7 +39,7 @@ class EntityTest: XCTestCase {
         let previousPagePath = previousPageComponents?.path
         let previousPageQuery = previousPageComponents?.query
 
-        let expectedPreviousPageQueryNode = Node(formURLEncoded: "page=1&count=2".bytes, allowEmptyValues: true)
+        let expectedPreviousPageQueryNode = Node(formURLEncoded: "page=1".bytes, allowEmptyValues: true)
         let actualPreviousPageQueryNode = Node(formURLEncoded: previousPageQuery!.bytes, allowEmptyValues: true)
         assertUnorderedEquals(actualPreviousPageQueryNode, expectedPreviousPageQueryNode)
 
@@ -49,12 +50,50 @@ class EntityTest: XCTestCase {
         let nextPagePath = nextPageComponents?.path
         let nextPageQuery = nextPageComponents?.query
 
-        let expectedNextPageQueryNode = Node(formURLEncoded: "page=3&count=2".bytes, allowEmptyValues: true)
+        let expectedNextPageQueryNode = Node(formURLEncoded: "page=3".bytes, allowEmptyValues: true)
         let actualNextPageQueryNode = Node(formURLEncoded: nextPageQuery!.bytes, allowEmptyValues: true)
         assertUnorderedEquals(actualNextPageQueryNode, expectedNextPageQueryNode)
 
         XCTAssertEqual(nextPagePath, "/users")
         XCTAssertEqual(paginator.totalPages, 3)
+        XCTAssertNotNil(paginator.total)
+        XCTAssertEqual(paginator.total, 6)
+    }
+
+    func testBasicWithCount() {
+        let request = Request(method: .get, uri: "/users?page=2&count=2")
+
+        //TODO(Brett): add `expect` tools
+        let paginator = try! TestUserEntity.paginator(2, request: request)
+
+        XCTAssertEqual(paginator.baseURI.path, "/users")
+
+        XCTAssertEqual(paginator.perPage, 2)
+        XCTAssertEqual(paginator.currentPage, 2)
+
+        XCTAssertEqual(paginator.pageName, "page")
+        XCTAssertEqual(paginator.dataKey, "data")
+
+        XCTAssertNotNil(paginator.previousPage)
+        let previousPageComponents = URLComponents(string: paginator.previousPage!)
+        let previousPagePath = previousPageComponents?.path
+        let previousPageQuery = previousPageComponents?.query
+        let expectedPreviousPageQueryNode = Node(formURLEncoded: "page=1&count=2".bytes, allowEmptyValues: true)
+        let actualPreviousPageQueryNode = Node(formURLEncoded: previousPageQuery!.bytes, allowEmptyValues: true)
+        XCTAssertEqual(expectedPreviousPageQueryNode, actualPreviousPageQueryNode)
+        XCTAssertEqual(previousPagePath, "/users")
+
+        XCTAssertNotNil(paginator.nextPage)
+        let nextPageComponents = URLComponents(string: paginator.nextPage!)
+        let nextPagePath = nextPageComponents?.path
+        let nextPageQuery = nextPageComponents?.query
+        let expectedNextPageQueryNode = Node(formURLEncoded: "page=3&count=2".bytes, allowEmptyValues: true)
+        let actualNextPageQueryNode = Node(formURLEncoded: nextPageQuery!.bytes, allowEmptyValues: true)
+        XCTAssertEqual(expectedNextPageQueryNode, actualNextPageQueryNode)
+        XCTAssertEqual(nextPagePath, "/users")
+
+        XCTAssertEqual(paginator.totalPages, 3)
+
         XCTAssertNotNil(paginator.total)
         XCTAssertEqual(paginator.total, 6)
     }
@@ -93,7 +132,7 @@ class EntityTest: XCTestCase {
         
         let actualNextPathComponents = URLComponents(string: (links["next"]?.string)!)
 
-        let expectedQueryNode = Node(formURLEncoded: "page=2&count=4".bytes, allowEmptyValues: true)
+        let expectedQueryNode = Node(formURLEncoded: "page=2".bytes, allowEmptyValues: true)
         let actualQueryNode = Node(formURLEncoded: actualNextPathComponents!.query!.bytes, allowEmptyValues: true)
 
         assertUnorderedEquals(actualQueryNode, expectedQueryNode)

--- a/Tests/PaginatorTests/LeafTests.swift
+++ b/Tests/PaginatorTests/LeafTests.swift
@@ -16,12 +16,13 @@ class LeafTests: XCTestCase {
         ("testNoNextPageWithBootstrap3", testNoNextPageWithBootstrap3),
         ("testNoPreviousPageWithBootstrap4", testNoPreviousPageWithBootstrap4),
         ("testNoNextPageWithBootstrap4", testNoNextPageWithBootstrap4),
+        ("testRunTagWithQueryParams", testRunTagWithQueryParams),
         ("testRunTagFailedTwoArgs", testRunTagFailedTwoArgs),
     ]
     
-    func testRunTag() {
+    func testRunTag() throws {
         let tag = PaginatorTag()
-        let paginator = buildPaginator()
+        let paginator = try buildPaginator()
         
         let result = expectNoThrow() {
             return try run(
@@ -43,7 +44,7 @@ class LeafTests: XCTestCase {
             "<nav class=\"paginator text-center\">\n" +
                 "<ul class=\"pagination\">\n" +
                     "<li>" +
-                        "<a href=\"/posts?page=1\" rel=\"prev\" aria-label=\"Previous\">" +
+                        "<a href=\"?page=1\" rel=\"prev\" aria-label=\"Previous\">" +
                             "<span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span>" +
                         "</a>" +
                     "</li>\n" +
@@ -76,7 +77,7 @@ class LeafTests: XCTestCase {
                         "<a href=\"?page=10\">10</a>" +
                     "</li>\n" +
                     "<li>" +
-                        "<a href=\"/posts?page=3\" rel=\"next\" aria-label=\"Next\">" +
+                        "<a href=\"?page=3\" rel=\"next\" aria-label=\"Next\">" +
                             "<span aria-hidden=\"true\">»</span>" +
                             "<span class=\"sr-only\">Next</span>" +
                         "</a>" +
@@ -87,9 +88,9 @@ class LeafTests: XCTestCase {
         XCTAssertEqual(bytes.makeString(), expectedHTML)
     }
     
-    func testRunTagWithAriaLabel() {
+    func testRunTagWithAriaLabel() throws {
         let tag = PaginatorTag(paginationLabel: "Some Aria Label Pages")
-        let paginator = buildPaginator()
+        let paginator = try buildPaginator()
         
         let result = expectNoThrow() {
             return try run(
@@ -111,7 +112,7 @@ class LeafTests: XCTestCase {
             "<nav class=\"paginator text-center\" aria-label=\"Some Aria Label Pages\">\n" +
                 "<ul class=\"pagination\">\n" +
                     "<li>" +
-                        "<a href=\"/posts?page=1\" rel=\"prev\" aria-label=\"Previous\">" +
+                        "<a href=\"?page=1\" rel=\"prev\" aria-label=\"Previous\">" +
                             "<span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span>" +
                         "</a>" +
                     "</li>\n" +
@@ -144,7 +145,7 @@ class LeafTests: XCTestCase {
                         "<a href=\"?page=10\">10</a>" +
                     "</li>\n" +
                     "<li>" +
-                        "<a href=\"/posts?page=3\" rel=\"next\" aria-label=\"Next\">" +
+                        "<a href=\"?page=3\" rel=\"next\" aria-label=\"Next\">" +
                             "<span aria-hidden=\"true\">»</span>" +
                             "<span class=\"sr-only\">Next</span>" +
                         "</a>" +
@@ -155,9 +156,9 @@ class LeafTests: XCTestCase {
         XCTAssertEqual(bytes.makeString(), expectedHTML)
     }
     
-    func testRunTagWithExplicitBootstrap3() {
+    func testRunTagWithExplicitBootstrap3() throws {
         let tag = PaginatorTag(useBootstrap4: false)
-        let paginator = buildPaginator()
+        let paginator = try buildPaginator()
         
         let result = expectNoThrow() {
             return try run(
@@ -179,7 +180,7 @@ class LeafTests: XCTestCase {
             "<nav class=\"paginator text-center\">\n" +
                 "<ul class=\"pagination\">\n" +
                     "<li>" +
-                        "<a href=\"/posts?page=1\" rel=\"prev\" aria-label=\"Previous\">" +
+                        "<a href=\"?page=1\" rel=\"prev\" aria-label=\"Previous\">" +
                             "<span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span>" +
                         "</a>" +
                     "</li>\n" +
@@ -205,7 +206,7 @@ class LeafTests: XCTestCase {
                     "<li><a href=\"?page=10\">10</a>" +
                     "</li>\n" +
                     "<li>" +
-                        "<a href=\"/posts?page=3\" rel=\"next\" aria-label=\"Next\">" +
+                        "<a href=\"?page=3\" rel=\"next\" aria-label=\"Next\">" +
                             "<span aria-hidden=\"true\">»</span>" +
                             "<span class=\"sr-only\">Next</span>" +
                         "</a>" +
@@ -216,9 +217,9 @@ class LeafTests: XCTestCase {
         XCTAssertEqual(bytes.makeString(), expectedHTML)
     }
     
-    func testRunTagWithBootstrap4() {
+    func testRunTagWithBootstrap4() throws {
         let tag = PaginatorTag(useBootstrap4: true)
-        let paginator = buildPaginator()
+        let paginator = try buildPaginator()
         
         let result = expectNoThrow() {
             return try run(
@@ -240,7 +241,7 @@ class LeafTests: XCTestCase {
             "<nav class=\"paginator\">\n" +
                 "<ul class=\"pagination justify-content-center\">\n" +
                     "<li class=\"page-item\">" +
-                        "<a href=\"/posts?page=1\" class=\"page-link\" rel=\"prev\" aria-label=\"Previous\">" +
+                        "<a href=\"?page=1\" class=\"page-link\" rel=\"prev\" aria-label=\"Previous\">" +
                             "<span aria-hidden=\"true\">«</span>" +
                             "<span class=\"sr-only\">Previous</span>" +
                         "</a>" +
@@ -274,7 +275,7 @@ class LeafTests: XCTestCase {
                         "<a href=\"?page=10\" class=\"page-link\">10</a>" +
                     "</li>\n" +
                     "<li class=\"page-item\">" +
-                        "<a href=\"/posts?page=3\" class=\"page-link\" rel=\"next\" aria-label=\"Next\">" +
+                        "<a href=\"?page=3\" class=\"page-link\" rel=\"next\" aria-label=\"Next\">" +
                             "<span aria-hidden=\"true\">»</span>" +
                             "<span class=\"sr-only\">Next</span>" +
                         "</a>" +
@@ -285,9 +286,9 @@ class LeafTests: XCTestCase {
         XCTAssertEqual(bytes.makeString(), expectedHTML)
     }
 
-    func testRunTagWithBootstrap4AndAriaLabel() {
+    func testRunTagWithBootstrap4AndAriaLabel() throws {
         let tag = PaginatorTag(useBootstrap4: true, paginationLabel: "Some Pages")
-        let paginator = buildPaginator()
+        let paginator = try buildPaginator()
         
         let result = expectNoThrow() {
             return try run(
@@ -309,7 +310,7 @@ class LeafTests: XCTestCase {
             "<nav class=\"paginator\" aria-label=\"Some Pages\">\n" +
                 "<ul class=\"pagination justify-content-center\">\n" +
                     "<li class=\"page-item\">" +
-                        "<a href=\"/posts?page=1\" class=\"page-link\" rel=\"prev\" aria-label=\"Previous\">" +
+                        "<a href=\"?page=1\" class=\"page-link\" rel=\"prev\" aria-label=\"Previous\">" +
                             "<span aria-hidden=\"true\">«</span>" +
                             "<span class=\"sr-only\">Previous</span>" +
                         "</a>" +
@@ -343,7 +344,7 @@ class LeafTests: XCTestCase {
                         "<a href=\"?page=10\" class=\"page-link\">10</a>" +
                     "</li>\n" +
                     "<li class=\"page-item\">" +
-                        "<a href=\"/posts?page=3\" class=\"page-link\" rel=\"next\" aria-label=\"Next\">" +
+                        "<a href=\"?page=3\" class=\"page-link\" rel=\"next\" aria-label=\"Next\">" +
                             "<span aria-hidden=\"true\">»</span>" +
                             "<span class=\"sr-only\">Next</span>" +
                         "</a>" +
@@ -354,9 +355,9 @@ class LeafTests: XCTestCase {
         XCTAssertEqual(bytes.makeString(), expectedHTML)
     }
 
-    func testNoPreviousPageWithBootstrap3() {
+    func testNoPreviousPageWithBootstrap3() throws {
         let tag = PaginatorTag(useBootstrap4: false, paginationLabel: "Some Pages")
-        let paginator = buildPaginator(currentPage: 1)
+        let paginator = try buildPaginator(currentPage: 1)
 
         let result = expectNoThrow() {
             return try run(
@@ -411,7 +412,7 @@ class LeafTests: XCTestCase {
                         "<a href=\"?page=10\">10</a>" +
                     "</li>\n" +
                     "<li>" +
-                        "<a href=\"/posts?page=2\" rel=\"next\" aria-label=\"Next\">" +
+                        "<a href=\"?page=2\" rel=\"next\" aria-label=\"Next\">" +
                             "<span aria-hidden=\"true\">»</span>" +
                             "<span class=\"sr-only\">Next</span>" +
                         "</a>" +
@@ -422,9 +423,9 @@ class LeafTests: XCTestCase {
         XCTAssertEqual(bytes.makeString(), expectedHTML)
     }
 
-    func testNoNextPageWithBootstrap3() {
+    func testNoNextPageWithBootstrap3() throws {
         let tag = PaginatorTag(useBootstrap4: false, paginationLabel: "Some Pages")
-        let paginator = buildPaginator(currentPage: 10)
+        let paginator = try buildPaginator(currentPage: 10)
         
         let result = expectNoThrow() {
             return try run(
@@ -443,7 +444,7 @@ class LeafTests: XCTestCase {
             "<nav class=\"paginator text-center\" aria-label=\"Some Pages\">\n" +
                 "<ul class=\"pagination\">\n" +
                     "<li>" +
-                        "<a href=\"/posts?page=9\" rel=\"prev\" aria-label=\"Previous\">" +
+                        "<a href=\"?page=9\" rel=\"prev\" aria-label=\"Previous\">" +
                             "<span aria-hidden=\"true\">«</span>" +
                             "<span class=\"sr-only\">Previous</span>" +
                         "</a>" +
@@ -493,9 +494,9 @@ class LeafTests: XCTestCase {
         XCTAssertEqual(bytes.makeString(), expectedHTML)
     }
     
-    func testNoPreviousPageWithBootstrap4() {
+    func testNoPreviousPageWithBootstrap4() throws {
         let tag = PaginatorTag(useBootstrap4: true, paginationLabel: "Some Pages")
-        let paginator = buildPaginator(currentPage: 1)
+        let paginator = try buildPaginator(currentPage: 1)
         
         let result = expectNoThrow() {
             return try run(
@@ -553,7 +554,7 @@ class LeafTests: XCTestCase {
                         "<a href=\"?page=10\" class=\"page-link\">10</a>" +
                     "</li>\n" +
                     "<li class=\"page-item\">" +
-                        "<a href=\"/posts?page=2\" class=\"page-link\" rel=\"next\" aria-label=\"Next\">" +
+                        "<a href=\"?page=2\" class=\"page-link\" rel=\"next\" aria-label=\"Next\">" +
                             "<span aria-hidden=\"true\">»</span>" +
                             "<span class=\"sr-only\">Next</span>" +
                         "</a>" +
@@ -564,9 +565,9 @@ class LeafTests: XCTestCase {
         XCTAssertEqual(bytes.makeString(), expectedHTML)
     }
     
-    func testNoNextPageWithBootstrap4() {
+    func testNoNextPageWithBootstrap4() throws {
         let tag = PaginatorTag(useBootstrap4: true, paginationLabel: "Some Pages")
-        let paginator = buildPaginator(currentPage: 10)
+        let paginator = try buildPaginator(currentPage: 10)
         
         let result = expectNoThrow() {
             return try run(
@@ -585,7 +586,7 @@ class LeafTests: XCTestCase {
             "<nav class=\"paginator\" aria-label=\"Some Pages\">\n" +
                 "<ul class=\"pagination justify-content-center\">\n" +
                     "<li class=\"page-item\">" +
-                        "<a href=\"/posts?page=9\" class=\"page-link\" rel=\"prev\" aria-label=\"Previous\">" +
+                        "<a href=\"?page=9\" class=\"page-link\" rel=\"prev\" aria-label=\"Previous\">" +
                             "<span aria-hidden=\"true\">«</span>" +
                             "<span class=\"sr-only\">Previous</span>" +
                         "</a>" +
@@ -634,6 +635,74 @@ class LeafTests: XCTestCase {
         
         XCTAssertEqual(bytes.makeString(), expectedHTML)
     }
+
+    func testRunTagWithQueryParams() throws {
+        let tag = PaginatorTag()
+        let paginator = try buildPaginator(query: ["foo": "bar"])
+
+        let result = expectNoThrow() {
+            return try run(
+                tag: tag,
+                context: paginator,
+                arguments: [
+                    .variable(path: [], value: paginator)
+                ]
+            )
+
+        }!
+
+        guard let bytes = result?.bytes else {
+            XCTFail("Should have returned bytes")
+            return
+        }
+
+        let expectedHTML =
+            "<nav class=\"paginator text-center\">\n" +
+                "<ul class=\"pagination\">\n" +
+                    "<li>" +
+                        "<a href=\"?page=1&foo=bar\" rel=\"prev\" aria-label=\"Previous\">" +
+                            "<span aria-hidden=\"true\">«</span><span class=\"sr-only\">Previous</span>" +
+                        "</a>" +
+                    "</li>\n" +
+                    "<li><a href=\"?page=1&foo=bar\">1</a></li>\n" +
+                    "<li class=\"active\"><a>" +
+                        "<span>2</span><span class=\"sr-only\">(current)</span></a>" +
+                    "</li>\n" +
+                    "<li>" +
+                        "<a href=\"?page=3&foo=bar\">3</a>" +
+                    "</li>\n" +
+                    "<li>" +
+                        "<a href=\"?page=4&foo=bar\">4</a>" +
+                    "</li>\n" +
+                    "<li>" +
+                        "<a href=\"?page=5&foo=bar\">5</a>" +
+                    "</li>\n" +
+                    "<li>" +
+                        "<a href=\"?page=6&foo=bar\">6</a>" +
+                    "</li>\n" +
+                    "<li>" +
+                        "<a href=\"?page=7&foo=bar\">7</a>" +
+                    "</li>\n" +
+                    "<li>" +
+                        "<a href=\"?page=8&foo=bar\">8</a>" +
+                    "</li>\n" +
+                    "<li>" +
+                        "<a href=\"?page=9&foo=bar\">9</a>" +
+                    "</li>\n" +
+                    "<li>" +
+                        "<a href=\"?page=10&foo=bar\">10</a>" +
+                    "</li>\n" +
+                    "<li>" +
+                        "<a href=\"?page=3&foo=bar\" rel=\"next\" aria-label=\"Next\">" +
+                            "<span aria-hidden=\"true\">»</span>" +
+                            "<span class=\"sr-only\">Next</span>" +
+                        "</a>" +
+                    "</li>\n" +
+                "</ul>\n" +
+            "</nav>"
+
+        XCTAssertEqual(bytes.makeString(), expectedHTML)
+    }
     
     func testRunTagFailedTwoArgs() {
         let tag = PaginatorTag()
@@ -650,22 +719,35 @@ class LeafTests: XCTestCase {
 }
 
 extension LeafTests {
-    func buildPaginator(currentPage: Int = 2) -> Node {
+
+    func buildPaginator(currentPage: Int = 2, query: Node = Node([:])) throws -> Node {
         var linksNode = Node([:])
-        
+        var queryNode = query
+
+        func addToLinksNode(key: String, page: Int) {
+            queryNode["page"] = page.makeNode(in: nil)
+            let path = PaginatorHelper.buildPath(
+                page: page,
+                count: 10,
+                uriQueries: query
+            )
+            linksNode[key] = path!.makeNode(in: nil)
+        }
+
         if currentPage > 1 {
-            linksNode["previous"] = Node("/posts?page=\(currentPage - 1)")
+            addToLinksNode(key: "previous", page: currentPage - 1)
         }
-        
+
         if currentPage < 10 {
-            linksNode["next"] = Node("/posts?page=\(currentPage + 1)")
+            addToLinksNode(key: "next", page: currentPage + 1)
         }
-        
-        return try! Node(node: [
-            "meta": try! Node(node: [
-                "paginator": try! Node(node: [
-                    "current_page": Node(currentPage),
+
+        return try Node(node: [
+            "meta": Node(node: [
+                "paginator": Node(node: [
+                    "current_page": currentPage.makeNode(in: nil),
                     "total_pages": 10,
+                    "queries": queryNode,
                     "links": linksNode
                 ])
             ])

--- a/Tests/PaginatorTests/PaginatorTests.swift
+++ b/Tests/PaginatorTests/PaginatorTests.swift
@@ -11,8 +11,7 @@ class PaginatorTests: XCTestCase {
     ]
 
     func testRequestQueryExtension() {
-        var request = Request(method: .get, uri: "/?key=value")
-        request = try! request.addingValues(["hello": "world"])
+        let request = Request(method: .get, uri: "/?key=value")
 
         guard var query = request.query?.object else {
             XCTFail("Query shouldn't be nil")
@@ -21,7 +20,6 @@ class PaginatorTests: XCTestCase {
         
         let expect: [String: Node] = [
             "key": "value",
-            "hello": "world"
         ]
         
         expect.forEach {

--- a/Tests/PaginatorTests/SequenceTests.swift
+++ b/Tests/PaginatorTests/SequenceTests.swift
@@ -19,7 +19,7 @@ class SequenceTests: XCTestCase {
     }
     
     func testBasic() {
-        let request = Request(method: .get, uri: "/users?page=2")
+        let request = Request(method: .get, uri: "/users?page=2&count=15")
         
         //TODO(Brett): add `expect` tools
         let paginator = try! TestUserEntity.all().paginator(2, request: request)
@@ -92,12 +92,10 @@ class SequenceTests: XCTestCase {
         XCTAssertNil(links["previous"]?.string)
         
         let actualNextPathComponents = URLComponents(string: (links["next"]?.string)!)
-        let expectedQueryNode = Node(formURLEncoded: "page=2&count=4".bytes, allowEmptyValues: true)
+        let expectedQueryNode = Node(formURLEncoded: "page=2".bytes, allowEmptyValues: true)
         let actualQueryNode = Node(formURLEncoded: actualNextPathComponents!.query!.bytes, allowEmptyValues: true)
 
         assertUnorderedEquals(actualQueryNode, expectedQueryNode)
         XCTAssertEqual(actualNextPathComponents?.path, "/users")
     }
-    
 }
-

--- a/Tests/PaginatorTests/SequenceTests.swift
+++ b/Tests/PaginatorTests/SequenceTests.swift
@@ -9,7 +9,6 @@ import Foundation
 class SequenceTests: XCTestCase {
     static var allTests = [
         ("testBasic", testBasic),
-        ("testAddingQueries", testAddingQueries),
         ("testMakeNode", testMakeNode),
         ]
     
@@ -58,28 +57,6 @@ class SequenceTests: XCTestCase {
         XCTAssertEqual(paginator.totalPages, 3)
         XCTAssertNotNil(paginator.total)
         XCTAssertEqual(paginator.total, 6)
-    }
-    
-    func testAddingQueries() {
-        let request = Request(method: .get, uri: "/users")
-        
-        //TODO(Brett): add `expect` tools
-        let paginator = try! TestUserEntity.all().paginator(
-            2,
-            request: request.addingValues(["search": "Brett"])
-        )
-        XCTAssertNil(paginator.previousPage)
-        XCTAssertNotNil(paginator.nextPage)
-        
-        let components = URLComponents(string: "/users?count=2&search=Brett&page=2")
-        let query = components?.query
-        let path = components?.path
-        
-        let queryNode = Node(formURLEncoded: query!.bytes, allowEmptyValues: true)
-        let expectedQueryNode = Node(formURLEncoded: "count=2&search=Brett&page=2".bytes, allowEmptyValues: true)
-        
-        assertUnorderedEquals(queryNode, expectedQueryNode)
-        XCTAssertEqual(path, "/users")
     }
     
     func testMakeNode() {


### PR DESCRIPTION
More or less the same implementation as for Vapor 1. Note that I removed `addingValues(..` since `Request.query` is now a computed property.