### PR TITLE
Vapor 3: Make OffsetQueryParams properties public

### DIFF
--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator.swift
@@ -55,8 +55,8 @@ public struct OffsetMetaData: Codable {
 }
 
 public struct OffsetQueryParams: Decodable, Reflectable {
-    let perPage: Int?
-    let page: Int?
+    public let perPage: Int?
+    public let page: Int?
 
     static public func decode(req: Request) throws -> Future<OffsetQueryParams> {
         let params = try req.query.decode(OffsetQueryParams.self)


### PR DESCRIPTION
Due to internal protection level you were not able to access the properties of OffsetQueryParams for you own Paginator implementation (that lives outside of this package).