### PR TITLE
Loosen restrictions

### DIFF
--- a/Sources/Paginator/Paginatable/QueryBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginatable/QueryBuilderPaginatable.swift
@@ -2,22 +2,20 @@ import Fluent
 import Vapor
 
 public protocol QueryBuilderPaginatable {
-    associatedtype ResultObject: Model
     associatedtype PaginatableMetaData
 
-    static func paginate(
-        query: QueryBuilder<ResultObject.Database, ResultObject>,
+    static func paginate<D: Database, Result>(
+        query: QueryBuilder<D, Result>,
         on req: Request
-    ) throws -> Future<([ResultObject], PaginatableMetaData)>
+    ) throws -> Future<([Result], PaginatableMetaData)>
 }
 
-public extension QueryBuilder where Result: Model, Result.Database == Database {
+public extension QueryBuilder {
     public func paginate<P: Paginator>(
         for req: Request
     ) throws -> Future<P> where
         P: QueryBuilderPaginatable,
         P.Object == Result,
-        P.ResultObject == Result,
         P.PaginatorMetaData == P.PaginatableMetaData
     {
         return try P.paginate(query: self, on: req).map { args -> P in

--- a/Sources/Paginator/Paginatable/QueryBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginatable/QueryBuilderPaginatable.swift
@@ -5,9 +5,19 @@ public protocol QueryBuilderPaginatable {
     associatedtype PaginatableMetaData
 
     static func paginate<D: Database, Result>(
+        count: Future<Int>,
         query: QueryBuilder<D, Result>,
         on req: Request
     ) throws -> Future<([Result], PaginatableMetaData)>
+}
+
+extension QueryBuilderPaginatable {
+    public static func paginate<D: Database, Result>(
+        query: QueryBuilder<D, Result>,
+        on req: Request
+    ) throws -> Future<([Result], PaginatableMetaData)> {
+        return try paginate(count: query.count(), query: query, on: req)
+    }
 }
 
 public extension QueryBuilder {

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+QueryBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+QueryBuilderPaginatable.swift
@@ -3,13 +3,6 @@ import Vapor
 
 extension OffsetPaginator: QueryBuilderPaginatable {
     public static func paginate<D: Database, Result>(
-        query: QueryBuilder<D, Result>,
-        on req: Request
-    ) throws -> Future<([Result], OffsetMetaData)> {
-        return try paginate(count: query.count(), query: query, on: req)
-    }
-
-    public static func paginate<D: Database, Result>(
         count: Future<Int>,
         query: QueryBuilder<D, Result>,
         on req: Request

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+QueryBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+QueryBuilderPaginatable.swift
@@ -1,11 +1,19 @@
 import Fluent
 import Vapor
 
-extension OffsetPaginator: QueryBuilderPaginatable where Object: Model {
-    public static func paginate(
-        query: QueryBuilder<Object.Database, Object>,
+extension OffsetPaginator: QueryBuilderPaginatable {
+    public static func paginate<D: Database, Result>(
+        query: QueryBuilder<D, Result>,
         on req: Request
-    ) throws -> Future<([Object], OffsetMetaData)> {
+    ) throws -> Future<([Result], OffsetMetaData)> {
+        return try paginate(count: query.count(), query: query, on: req)
+    }
+
+    public static func paginate<D: Database, Result>(
+        count: Future<Int>,
+        query: QueryBuilder<D, Result>,
+        on req: Request
+    ) throws -> Future<([Result], OffsetMetaData)> {
         let config: OffsetPaginatorConfig = (try? req.make()) ?? .default
         return try OffsetQueryParams.decode(req: req)
             .flatMap { params in
@@ -14,18 +22,16 @@ extension OffsetPaginator: QueryBuilderPaginatable where Object: Model {
                 let lower = (page - 1) * perPage
                 let upper = (lower + perPage) - 1
 
-                return query.count()
-                    .flatMap { count in
-                        let data = try OffsetMetaData(
-                            currentPage: page,
-                            perPage: perPage,
-                            total: count,
-                            on: req
-                        )
-                        return query.range(lower: lower, upper: upper).all()
-                            .map { ($0, data) }
-                    }
+                return count.flatMap { count in
+                    let data = try OffsetMetaData(
+                        currentPage: page,
+                        perPage: perPage,
+                        total: count,
+                        on: req
+                    )
+                    return query.range(lower: lower, upper: upper).all()
+                        .map { ($0, data) }
+                }
             }
     }
 }
-


### PR DESCRIPTION
Allow creating pagination data from QueryBuilders with different Result type than the Paginator. This helps in cases where the Result type is not Codable (e.g. tuples). It should be considered whether this method should be on Paginators at all since the Result types are now decoupled. 
Also, this PR adds the possibility to specify your own `count` producing Future. This is needed in cases where `query.count()` does not produce the right result (e.g. when there is a "GROUP BY" clause).