### PR TITLE
Downgrade Swift dependency to 4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/fluent.git", from: "3.0.0"),
         .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),
-        .package(url: "https://github.com/nodes-vapor/sugar.git", from: "3.0.0-beta"),
+        .package(url: "https://github.com/cb1674/sugar.git", from: "3.0.1"),
     ],
     targets: [
         .target(name: "Paginator", dependencies: ["Fluent", "Vapor", "Sugar"]),

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginatorLinks.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginatorLinks.swift
@@ -22,7 +22,7 @@ public extension OffsetMetaData {
     }
 
     public func links(
-        in range: ClosedRange<Int>
+        in range: CountableClosedRange<Int>
     ) throws -> [String] {
         return try range.map { try link(for: $0) }
     }

--- a/Sources/Paginator/Tags/OffsetPaginatorControlData.swift
+++ b/Sources/Paginator/Tags/OffsetPaginatorControlData.swift
@@ -61,7 +61,7 @@ public struct OffsetPaginatorControlData: Codable {
                 total: metaData.totalPages
             )
 
-            let range = bounds.lower...bounds.upper
+            let range : CountableClosedRange = bounds.lower...bounds.upper
             let middleLinks = try metaData.links(in: range)
             middle = zip(range, middleLinks).map { (page, url) in
                 Control(url: url, page: page)


### PR DESCRIPTION
Updated PR:
I replaced the ClosedRange to a CountableClosedRange as map() is not available in Swift 4.1.
I don't think it could have drawbacks in this context.
I also downgraded the swift dependency in Package.swift to 4.0.