### PR TITLE
Downgrade Swift dependency to 4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.1
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Paginator 🗂
-[![Swift Version](https://img.shields.io/badge/Swift-4.2-brightgreen.svg)](http://swift.org)
+[![Swift Version](https://img.shields.io/badge/Swift-4.1-brightgreen.svg)](http://swift.org)
 [![Vapor Version](https://img.shields.io/badge/Vapor-3-30B6FC.svg)](http://vapor.codes)
 [![Circle CI](https://circleci.com/gh/nodes-vapor/paginator/tree/master.svg?style=shield)](https://circleci.com/gh/nodes-vapor/paginator)
 [![codebeat badge](https://codebeat.co/badges/292edd79-f237-4df5-8d6b-9ef748148d80)](https://codebeat.co/projects/github-com-nodes-vapor-paginator-master)

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginatorLinks.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginatorLinks.swift
@@ -22,7 +22,7 @@ public extension OffsetMetaData {
     }
 
     public func links(
-        in range: ClosedRange<Int>
+        in range: CountableClosedRange<Int>
     ) throws -> [String] {
         return try range.map { try link(for: $0) }
     }

--- a/Sources/Paginator/Tags/OffsetPaginatorControlData.swift
+++ b/Sources/Paginator/Tags/OffsetPaginatorControlData.swift
@@ -61,7 +61,7 @@ public struct OffsetPaginatorControlData: Codable {
                 total: metaData.totalPages
             )
 
-            let range = bounds.lower...bounds.upper
+            let range : CountableClosedRange = bounds.lower...bounds.upper
             let middleLinks = try metaData.links(in: range)
             middle = zip(range, middleLinks).map { (page, url) in
                 Control(url: url, page: page)

--- a/Sources/Paginator/Tags/OffsetPaginatorControlData.swift
+++ b/Sources/Paginator/Tags/OffsetPaginatorControlData.swift
@@ -61,7 +61,7 @@ public struct OffsetPaginatorControlData: Codable {
                 total: metaData.totalPages
             )
 
-            let range : CountableClosedRange = bounds.lower...bounds.upper
+            let range: CountableClosedRange = bounds.lower...bounds.upper
             let middleLinks = try metaData.links(in: range)
             middle = zip(range, middleLinks).map { (page, url) in
                 Control(url: url, page: page)


### PR DESCRIPTION
I replaced the ClosedRange to a CountableClosedRange as map() is not available in Swift 4.1.
I also downgraded the swift dependency in Package.swift to 4.1.