### PR TITLE
Add RawSQLBuilderPaginatable to paginate raw queries not compatible with Fluent.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/fluent.git", from: "3.0.0"),
         .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),
+        .package(url: "https://github.com/vapor/sql.git", from: "2.3.2"),
     ],
     targets: [
-        .target(name: "Paginator", dependencies: ["Fluent", "Vapor"]),
+        .target(name: "Paginator", dependencies: ["Fluent", "Vapor", "SQL"]),
         .testTarget(name: "PaginatorTests", dependencies: ["Paginator"]),
     ]
 )

--- a/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
@@ -1,0 +1,103 @@
+import Fluent
+import Vapor
+import SQL
+
+protocol RawSQLBuilderPaginatable: Paginatable {
+    associatedtype PaginatableMetaData
+    
+    static func paginate<D: Database, Result>(
+        source: RawSQLBuilder<D, Result>,
+        count: Future<Int>,
+        on req: Request
+        ) throws -> Future<([Result], PaginatableMetaData)>
+}
+
+class RawSQLBuilder<Database, Result> where Database: DatabaseKit.Database, Database.Connection: SQLConnectable, Result: Decodable {
+    let sqlRawBuilder: SQLRawBuilder<Database.Connection>
+    let sqlRawCountBuilder: SQLRawBuilder<Database.Connection>?
+    
+    struct CountResult: Codable {
+        let count: Int
+    }
+    
+    init(query: String, countQuery: String, connection: Database.Connection) {
+        self.sqlRawBuilder = connection.raw(query)
+        self.sqlRawCountBuilder = connection.raw(countQuery)
+    }
+}
+
+extension RawSQLBuilder {
+    func count(for req: Request) throws -> EventLoopFuture<Int> {
+        guard let sqlRawCountBuilder = sqlRawCountBuilder else {
+            throw Abort(HTTPStatus.internalServerError, reason: "Cannot compute count")
+        }
+        
+        return sqlRawCountBuilder.all(decoding: CountResult.self).map({ output in
+            return output.first?.count ?? 0
+        })
+    }
+    
+    func paginate<P: Paginator>(
+        for req: Request
+        ) throws -> Future<P> where
+        P: RawSQLBuilderPaginatable,
+        P.Object == Result,
+        P.PaginatorMetaData == P.PaginatableMetaData
+    {
+        return try self.paginate(count: self.count(for: req), for: req)
+    }
+    
+    func paginate<P: Paginator>(
+        count: Future<Int>,
+        for req: Request
+        ) throws -> Future<P> where
+        P: RawSQLBuilderPaginatable,
+        P.Object == Result,
+        P.PaginatorMetaData == P.PaginatableMetaData
+    {
+        return try P.paginate(source: self, count: count, on: req).map { args -> P in
+            let (results, data) = args
+            return try P(data: results, meta: data)
+        }
+    }
+}
+
+extension RawSQLBuilder: Transformable {
+    typealias TransformableQuery = RawSQLBuilder<Database, Result>
+    typealias TransformableQueryResult = Result
+}
+
+extension TransformingQuery {
+    func paginate<P: Paginator, Database>(
+        for req: Request
+        ) throws -> Future<P> where
+        P: RawSQLBuilderPaginatable,
+        Query: RawSQLBuilder<Database, Result>,
+        TransformedResult == P.Object,
+        P.PaginatorMetaData == P.PaginatableMetaData
+    {
+        return try self.paginate(count: self.source.count(for: req), for: req)
+    }
+    
+    func paginate<P: Paginator, Database>(
+        count: Future<Int>,
+        for req: Request
+        ) throws -> Future<P> where
+        P: RawSQLBuilderPaginatable,
+        Query: RawSQLBuilder<Database, Result>,
+        TransformedResult == P.Object,
+        P.PaginatorMetaData == P.PaginatableMetaData
+    {
+        return try P.paginate(
+            source: self.source,
+            count: count,
+            on: req
+            )
+            .flatMap { args -> Future<P> in
+                let (results, data) = args
+                return try self.transform(results).map { results in
+                    return try P(data: results, meta: data)
+                }
+        }
+    }
+}

--- a/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
@@ -9,10 +9,14 @@ protocol RawSQLBuilderPaginatable: Paginatable {
         source: RawSQLBuilder<D, Result>,
         count: Future<Int>,
         on req: Request
-        ) throws -> Future<([Result], PaginatableMetaData)>
+    ) throws -> Future<([Result], PaginatableMetaData)>
 }
 
-class RawSQLBuilder<Database, Result> where Database: DatabaseKit.Database, Database.Connection: SQLConnectable, Result: Decodable {
+class RawSQLBuilder<Database, Result> where
+    Database: DatabaseKit.Database,
+    Database.Connection: SQLConnectable,
+    Result: Decodable
+{
     let sqlRawBuilder: SQLRawBuilder<Database.Connection>
     let sqlRawCountBuilder: SQLRawBuilder<Database.Connection>?
     
@@ -20,8 +24,14 @@ class RawSQLBuilder<Database, Result> where Database: DatabaseKit.Database, Data
         let count: Int
     }
     
-    init(query: String, countQuery: String, connection: Database.Connection) {
+    init(query: String, countQuery: String?, connection: Database.Connection) {
         self.sqlRawBuilder = connection.raw(query)
+        
+        guard let countQuery = countQuery else {
+            self.sqlRawCountBuilder = nil
+            return
+        }
+        
         self.sqlRawCountBuilder = connection.raw(countQuery)
     }
 }
@@ -39,7 +49,7 @@ extension RawSQLBuilder {
     
     func paginate<P: Paginator>(
         for req: Request
-        ) throws -> Future<P> where
+    ) throws -> Future<P> where
         P: RawSQLBuilderPaginatable,
         P.Object == Result,
         P.PaginatorMetaData == P.PaginatableMetaData
@@ -50,7 +60,7 @@ extension RawSQLBuilder {
     func paginate<P: Paginator>(
         count: Future<Int>,
         for req: Request
-        ) throws -> Future<P> where
+    ) throws -> Future<P> where
         P: RawSQLBuilderPaginatable,
         P.Object == Result,
         P.PaginatorMetaData == P.PaginatableMetaData
@@ -70,7 +80,7 @@ extension RawSQLBuilder: Transformable {
 extension TransformingQuery {
     func paginate<P: Paginator, Database>(
         for req: Request
-        ) throws -> Future<P> where
+    ) throws -> Future<P> where
         P: RawSQLBuilderPaginatable,
         Query: RawSQLBuilder<Database, Result>,
         TransformedResult == P.Object,
@@ -82,17 +92,14 @@ extension TransformingQuery {
     func paginate<P: Paginator, Database>(
         count: Future<Int>,
         for req: Request
-        ) throws -> Future<P> where
+    ) throws -> Future<P> where
         P: RawSQLBuilderPaginatable,
         Query: RawSQLBuilder<Database, Result>,
         TransformedResult == P.Object,
         P.PaginatorMetaData == P.PaginatableMetaData
     {
-        return try P.paginate(
-            source: self.source,
-            count: count,
-            on: req
-            )
+        return try P
+            .paginate(source: self.source, count: count, on: req)
             .flatMap { args -> Future<P> in
                 let (results, data) = args
                 return try self.transform(results).map { results in

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+RawSQLBuilderPaginatable.swift
@@ -1,0 +1,37 @@
+import Fluent
+import Vapor
+
+extension OffsetPaginator: RawSQLBuilderPaginatable {
+    // This shouldn't be called directly - please use the extension on QueryBuilder instead.
+    static func paginate<D: Database, Result>(
+        source: RawSQLBuilder<D, Result>,
+        count: Future<Int>,
+        on req: Request
+        ) throws -> Future<([Result], OffsetMetaData)> {
+        let config: OffsetPaginatorConfig = (try? req.make()) ?? .default
+        return try OffsetQueryParams.decode(req: req)
+            .flatMap { params in
+                let page = params.page ?? config.defaultPage
+                let perPage = params.perPage ?? config.perPage
+                let lower = (page - 1) * perPage
+                
+                source.sqlRawBuilder.sql.append("""
+                    
+                    LIMIT \(perPage)
+                    OFFSET \(lower)
+                    """
+                )
+                return count.flatMap { count in
+                    let data = try OffsetMetaData(
+                        currentPage: page,
+                        perPage: perPage,
+                        total: count,
+                        on: req
+                    )
+                    return source.sqlRawBuilder.all(decoding: Result.self).map({ output in
+                        (output, data)
+                    })
+                }
+        }
+    }
+}

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+RawSQLBuilderPaginatable.swift
@@ -7,7 +7,7 @@ extension OffsetPaginator: RawSQLBuilderPaginatable {
         source: RawSQLBuilder<D, Result>,
         count: Future<Int>,
         on req: Request
-        ) throws -> Future<([Result], OffsetMetaData)> {
+    ) throws -> Future<([Result], OffsetMetaData)> {
         let config: OffsetPaginatorConfig = (try? req.make()) ?? .default
         return try OffsetQueryParams.decode(req: req)
             .flatMap { params in
@@ -15,12 +15,7 @@ extension OffsetPaginator: RawSQLBuilderPaginatable {
                 let perPage = params.perPage ?? config.perPage
                 let lower = (page - 1) * perPage
                 
-                source.sqlRawBuilder.sql.append("""
-                    
-                    LIMIT \(perPage)
-                    OFFSET \(lower)
-                    """
-                )
+                source.sqlRawBuilder.sql.append("\nLIMIT \(perPage)\nOFFSET \(lower)")
                 return count.flatMap { count in
                     let data = try OffsetMetaData(
                         currentPage: page,


### PR DESCRIPTION
Hi,

I needed to display some informations on a paginated page using information that I would not be able to get with Fluent, both with request complexity and with mapping to a Swift object (multiple group by, counts in the columns).

I tried my best to mimic the behavior of the `QueryBuilderPaginatable` since it's generic focused.
___
### Example 

In order to use it, you will need a `Database.Connection`

_With PostgreSQL:_
```swift
return req.withPooledConnection(to: .psql) { conn in
    let rawBuilder = RawSQLBuilder<PostgreSQLDatabase, __DATA_TYPE__>("__DATA__QUERY_STRING__", countQuery: "__COUNT_QUERY_STRING__", connection: conn)
    let paginator: Future<OffsetPaginator<__DATA_TYPE__>> = try rawBuilder.paginate(for: req)
}
```
`___DATA_TYPE__` needs to be `Codable`

___
### Count

You always have to provide a counting query string (I'm not parsing the query to modify it and find the count of what you are looking for, it could maybe be made), note that the count query is expected to have a result with one column named `count` and with the total columns value in the first row. You can also provide your own count producing `Future` and not use a raw query string as seen in #54

|   | `count` |
|---|-------|
| `1` | 42    |

___
### Method

Also, pagination is made by appending `LIMIT` and `OFFSET` to the SQL query string, I don't know if this solution is foolproof but I wanted the more generic solution to offer.
___
### Notes

This Pull Request adds the Vapor SQL Package dependency to the Nodes Paginator Package