### PR TITLE
Change RawSQLBuilder access modifiers to public

### DIFF
--- a/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
@@ -2,7 +2,7 @@ import Fluent
 import Vapor
 import SQL
 
-protocol RawSQLBuilderPaginatable: Paginatable {
+public protocol RawSQLBuilderPaginatable: Paginatable {
     associatedtype PaginatableMetaData
     
     static func paginate<D: Database, Result>(
@@ -12,7 +12,7 @@ protocol RawSQLBuilderPaginatable: Paginatable {
     ) throws -> Future<([Result], PaginatableMetaData)>
 }
 
-class RawSQLBuilder<Database, Result> where
+public class RawSQLBuilder<Database, Result> where
     Database: DatabaseKit.Database,
     Database.Connection: SQLConnectable,
     Result: Decodable
@@ -24,7 +24,7 @@ class RawSQLBuilder<Database, Result> where
         let count: Int
     }
     
-    init(query: String, countQuery: String?, connection: Database.Connection) {
+    public init(query: String, countQuery: String?, connection: Database.Connection) {
         self.sqlRawBuilder = connection.raw(query)
         
         guard let countQuery = countQuery else {
@@ -36,7 +36,7 @@ class RawSQLBuilder<Database, Result> where
     }
 }
 
-extension RawSQLBuilder {
+public extension RawSQLBuilder {
     func count(for req: Request) throws -> EventLoopFuture<Int> {
         guard let sqlRawCountBuilder = sqlRawCountBuilder else {
             throw Abort(HTTPStatus.internalServerError, reason: "Cannot compute count")
@@ -73,11 +73,11 @@ extension RawSQLBuilder {
 }
 
 extension RawSQLBuilder: Transformable {
-    typealias TransformableQuery = RawSQLBuilder<Database, Result>
-    typealias TransformableQueryResult = Result
+    public typealias TransformableQuery = RawSQLBuilder<Database, Result>
+    public typealias TransformableQueryResult = Result
 }
 
-extension TransformingQuery {
+public extension TransformingQuery {
     func paginate<P: Paginator, Database>(
         for req: Request
     ) throws -> Future<P> where

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+RawSQLBuilderPaginatable.swift
@@ -3,7 +3,7 @@ import Vapor
 
 extension OffsetPaginator: RawSQLBuilderPaginatable {
     // This shouldn't be called directly - please use the extension on QueryBuilder instead.
-    static func paginate<D: Database, Result>(
+    public static func paginate<D: Database, Result>(
         source: RawSQLBuilder<D, Result>,
         count: Future<Int>,
         on req: Request


### PR DESCRIPTION
Currently "RawSQLBuilder" and other functions related to RawSQL are unaccessible.

Defining a variable gives the error: `Use of unresolved identifier 'RawSQLBuilder'`

I've just made a simple fix to use `public` access modifier.