### PR TITLE
Enable specifying paginator type

### DIFF
--- a/Sources/Paginator/Paginatable/ArrayPaginatable.swift
+++ b/Sources/Paginator/Paginatable/ArrayPaginatable.swift
@@ -21,7 +21,8 @@ public extension ArrayPaginatable {
 
 public extension Array where Iterator.Element: Codable {
     func paginate<P: Paginator>(
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         P: ArrayPaginatable,
         P.Object == Iterator.Element,
@@ -33,7 +34,8 @@ public extension Array where Iterator.Element: Codable {
 
     func paginate<P: Paginator>(
         count: Int,
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         P: ArrayPaginatable,
         P.Object == Iterator.Element,
@@ -54,7 +56,8 @@ extension Array: Transformable where Iterator.Element: Codable {
 
 public extension TransformingQuery {
     func paginate<P: Paginator>(
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         P: ArrayPaginatable,
         P.PaginatorMetaData == P.PaginatableMetaData,
@@ -66,7 +69,8 @@ public extension TransformingQuery {
 
     func paginate<P: Paginator>(
         count: Int,
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         P: ArrayPaginatable,
         P.PaginatorMetaData == P.PaginatableMetaData,

--- a/Sources/Paginator/Paginatable/QueryBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginatable/QueryBuilderPaginatable.swift
@@ -13,7 +13,8 @@ public protocol QueryBuilderPaginatable: Paginatable {
 
 public extension QueryBuilder {
     func paginate<P: Paginator>(
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         P: QueryBuilderPaginatable,
         P.Object == Result,
@@ -24,7 +25,8 @@ public extension QueryBuilder {
 
     func paginate<P: Paginator>(
         count: Future<Int>,
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         P: QueryBuilderPaginatable,
         P.Object == Result,
@@ -41,7 +43,8 @@ extension QueryBuilder: Transformable {
 
 public extension TransformingQuery {
     func paginate<P: Paginator, T>(
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         T: QuerySupporting,
         P: QueryBuilderPaginatable,
@@ -54,7 +57,8 @@ public extension TransformingQuery {
 
     func paginate<P: Paginator, T>(
         count: Future<Int>,
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         T: QuerySupporting,
         P: QueryBuilderPaginatable,

--- a/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
@@ -48,7 +48,8 @@ public extension RawSQLBuilder {
     }
     
     func paginate<P: Paginator>(
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         P: RawSQLBuilderPaginatable,
         P.Object == Result,
@@ -59,7 +60,8 @@ public extension RawSQLBuilder {
     
     func paginate<P: Paginator>(
         count: Future<Int>,
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         P: RawSQLBuilderPaginatable,
         P.Object == Result,
@@ -79,7 +81,8 @@ extension RawSQLBuilder: Transformable {
 
 public extension TransformingQuery {
     func paginate<P: Paginator, Database>(
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         P: RawSQLBuilderPaginatable,
         Query: RawSQLBuilder<Database, Result>,
@@ -91,7 +94,8 @@ public extension TransformingQuery {
     
     func paginate<P: Paginator, Database>(
         count: Future<Int>,
-        for req: Request
+        for req: Request,
+        type: P.Type = P.self
     ) throws -> Future<P> where
         P: RawSQLBuilderPaginatable,
         Query: RawSQLBuilder<Database, Result>,


### PR DESCRIPTION
This helps in scenarios where type inference is not possible due to
chaining operations.