### PR TITLE
Allow parameterized queries on RawSQLBuilder

### DIFF
--- a/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
@@ -34,6 +34,18 @@ public class RawSQLBuilder<Database, Result> where
         
         self.sqlRawCountBuilder = connection.raw(countQuery)
     }
+    
+    public func bind(_ encodable: Encodable) -> Self {
+        _ = sqlRawBuilder.bind(encodable)
+        _ = sqlRawCountBuilder?.bind(encodable)
+        return self
+    }
+    
+    public func binds(_ encodables: [Encodable]) -> Self {
+        _ = sqlRawBuilder.binds(encodables)
+        _ = sqlRawCountBuilder?.binds(encodables)
+        return self
+    }
 }
 
 public extension RawSQLBuilder {


### PR DESCRIPTION
This PR adds functionality to call `.binds` and `.bind` on a RawSQLBuilder object in order to support parameterized queries.