### PR TITLE
Feature/enable external pagination sources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   MacOS:
     macos:
-      xcode: "10.0.0"
+      xcode: "10.3.0"
     steps:
       - checkout
       - restore_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bower_components/
 CMakeLists.txt
 Package.pins
 Package.resolved
+.swiftpm

--- a/Sources/Paginator/Paginatable/ArrayPaginatable.swift
+++ b/Sources/Paginator/Paginatable/ArrayPaginatable.swift
@@ -42,9 +42,8 @@ public extension Array where Iterator.Element: Codable {
         P.ResultObject == Iterator.Element,
         P.PaginatorMetaData == P.PaginatableMetaData
     {
-        return try P.paginate(source: self, count: count, on: req).map { args -> P in
-            let (results, data) = args
-            return try P(data: results, meta: data)
+        return try P.paginate(source: self, count: count, on: req).map { results, data in
+            try P(data: results, meta: data)
         }
     }
 }
@@ -84,7 +83,7 @@ public extension TransformingQuery {
         )
         .flatMap { results, data -> Future<P> in
             try self.transform(results).map { results in
-                return try P(data: results, meta: data)
+                try P(data: results, meta: data)
             }
         }
     }

--- a/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginatable/RawSQLBuilderPaginatable.swift
@@ -79,9 +79,8 @@ public extension RawSQLBuilder {
         P.Object == Result,
         P.PaginatorMetaData == P.PaginatableMetaData
     {
-        return try P.paginate(source: self, count: count, on: req).map { args -> P in
-            let (results, data) = args
-            return try P(data: results, meta: data)
+        return try P.paginate(source: self, count: count, on: req).map { results, data -> P in
+            try P(data: results, meta: data)
         }
     }
 }
@@ -116,10 +115,9 @@ public extension TransformingQuery {
     {
         return try P
             .paginate(source: self.source, count: count, on: req)
-            .flatMap { args -> Future<P> in
-                let (results, data) = args
-                return try self.transform(results).map { results in
-                    return try P(data: results, meta: data)
+            .flatMap { results, data in
+                try self.transform(results).map { results in
+                    try P(data: results, meta: data)
                 }
         }
     }

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+ArrayPaginatable.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+ArrayPaginatable.swift
@@ -8,8 +8,8 @@ extension OffsetPaginator: ArrayPaginatable {
         source: [Object],
         count: Int,
         on req: Request
-    ) throws -> Future<([Object], OffsetMetaData)> {
-        return try offsetMetaData(count: count, on: req) { metadata in
+    ) -> Future<([Object], OffsetMetaData)> {
+        return offsetMetaData(count: count, on: req) { metadata in
             Future.map(on: req) {
                 guard
                     metadata.currentPage <= metadata.totalPages,

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+QueryBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+QueryBuilderPaginatable.swift
@@ -7,9 +7,9 @@ extension OffsetPaginator: QueryBuilderPaginatable {
         source: QueryBuilder<D, Result>,
         count: Future<Int>,
         on req: Request
-    ) throws -> Future<([Result], OffsetMetaData)> {
+    ) -> Future<([Result], OffsetMetaData)> {
         return count.flatMap { count in
-            try offsetMetaData(count: count, on: req) { metadata in
+            offsetMetaData(count: count, on: req) { metadata in
                 source
                     .range(lower: metadata.lower, upper: metadata.upper)
                     .all()

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+RawSQLBuilderPaginatable.swift
@@ -8,25 +8,11 @@ extension OffsetPaginator: RawSQLBuilderPaginatable {
         count: Future<Int>,
         on req: Request
     ) throws -> Future<([Result], OffsetMetaData)> {
-        let config: OffsetPaginatorConfig = (try? req.make()) ?? .default
-        return try OffsetQueryParams.decode(req: req)
-            .flatMap { params in
-                let page = params.page ?? config.defaultPage
-                let perPage = params.perPage ?? config.perPage
-                let lower = (page - 1) * perPage
-                
-                source.sqlRawBuilder.sql.append("\nLIMIT \(perPage)\nOFFSET \(lower)")
-                return count.flatMap { count in
-                    let data = try OffsetMetaData(
-                        currentPage: page,
-                        perPage: perPage,
-                        total: count,
-                        on: req
-                    )
-                    return source.sqlRawBuilder.all(decoding: Result.self).map({ output in
-                        (output, data)
-                    })
-                }
+        return count.flatMap { count in
+            try offsetMetaData(count: count, on: req) { metadata in
+                source.sqlRawBuilder.sql.append("\nLIMIT \(metadata.perPage)\nOFFSET \(metadata.lower)")
+                return source.sqlRawBuilder.all(decoding: Result.self)
+            }
         }
     }
 }

--- a/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+RawSQLBuilderPaginatable.swift
+++ b/Sources/Paginator/Paginators/OffsetPaginator/OffsetPaginator+RawSQLBuilderPaginatable.swift
@@ -7,9 +7,9 @@ extension OffsetPaginator: RawSQLBuilderPaginatable {
         source: RawSQLBuilder<D, Result>,
         count: Future<Int>,
         on req: Request
-    ) throws -> Future<([Result], OffsetMetaData)> {
+    ) -> Future<([Result], OffsetMetaData)> {
         return count.flatMap { count in
-            try offsetMetaData(count: count, on: req) { metadata in
+            offsetMetaData(count: count, on: req) { metadata in
                 source.sqlRawBuilder.sql.append("\nLIMIT \(metadata.perPage)\nOFFSET \(metadata.lower)")
                 return source.sqlRawBuilder.all(decoding: Result.self)
             }

--- a/Sources/Paginator/Transform.swift
+++ b/Sources/Paginator/Transform.swift
@@ -1,8 +1,8 @@
 import Vapor
 
 public struct TransformingQuery<Query, Result, TransformedResult: Codable> {
-    let source: Query
-    let transform: ([Result]) throws -> Future<[TransformedResult]>
+    public let source: Query
+    public let transform: ([Result]) throws -> Future<[TransformedResult]>
 }
 
 public protocol Transformable {


### PR DESCRIPTION
This enables creating pagination sources outside this package with less code duplication. For instance using SwifQL without importing it here.