### PR TITLE
Bump swift to 5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   MacOS:
     macos:
-      xcode: "10.0.0"
+      xcode: "11.2.1"
     steps:
       - checkout
       - restore_cache:
@@ -31,12 +31,12 @@ jobs:
             - .build
   Linux:
     docker:
-      - image: nodesvapor/vapor-ci:swift-4.2
+      - image: nodesvapor/vapor-ci:swift-5.1
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v2-spm-deps-{{ checksum "Package.swift" }}
+            - v1-spm-deps-{{ checksum "Package.swift" }}
       - run:
           name: Copy Package File
           command: cp Package.swift res
@@ -44,12 +44,12 @@ jobs:
           name: Build and Run Tests
           no_output_timeout: 1800
           command: |
-            swift test -Xswiftc -DNOJSON
+            swift test --enable-test-discovery
       - run:
           name: Restoring Package File
           command: mv res Package.swift
       - save_cache:
-          key: v2-spm-deps-{{ checksum "Package.swift" }}
+          key: v1-spm-deps-{{ checksum "Package.swift" }}
           paths:
             - .build
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-spm-deps-{{ checksum "Package.swift" }}
+            - v2-spm-deps-{{ checksum "Package.swift" }}
       - run:
           name: Install dependencies
           command: |
@@ -26,7 +26,7 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash)
       - save_cache:
-          key: v1-spm-deps-{{ checksum "Package.swift" }}
+          key: v2-spm-deps-{{ checksum "Package.swift" }}
           paths:
             - .build
   Linux:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Paginator 🗂
-[![Swift Version](https://img.shields.io/badge/Swift-4.1-brightgreen.svg)](http://swift.org)
+[![Swift Version](https://img.shields.io/badge/Swift-5.1-brightgreen.svg)](http://swift.org)
 [![Vapor Version](https://img.shields.io/badge/Vapor-3-30B6FC.svg)](http://vapor.codes)
 [![Circle CI](https://circleci.com/gh/nodes-vapor/paginator/tree/master.svg?style=shield)](https://circleci.com/gh/nodes-vapor/paginator)
 [![codebeat badge](https://codebeat.co/badges/292edd79-f237-4df5-8d6b-9ef748148d80)](https://codebeat.co/projects/github-com-nodes-vapor-paginator-master)
@@ -17,7 +17,7 @@ Add `Paginator` to the package dependencies (in your `Package.swift` file):
 ```swift
 dependencies: [
     ...,
-    .package(url: "https://github.com/nodes-vapor/paginator.git", from: "3.0.0-rc")
+    .package(url: "https://github.com/nodes-vapor/paginator.git", from: "3.0.0")
 ]
 ```
 


### PR DESCRIPTION
Is this a breaking change? The current version broke CI so an update was required anyway.